### PR TITLE
Use non-strict JSON parsing to overcome XML EPG with escaped characters

### DIFF
--- a/tvhProxy.py
+++ b/tvhProxy.py
@@ -117,7 +117,7 @@ def _get_channels():
     try:
         r = requests.get(url, params=params, auth=HTTPDigestAuth(
             config['tvhUser'], config['tvhPassword']))
-        return r.json()['entries']
+        return r.json(strict=False)['entries']
 
     except Exception as e:
         logger.error('An error occured: %s' + repr(e))
@@ -136,10 +136,10 @@ def _get_genres():
     try:
         r = requests.get(url, auth=HTTPDigestAuth(
             config['tvhUser'], config['tvhPassword']))
-        entries = r.json()['entries']
+        entries = r.json(strict=False)['entries']
         r = requests.get(url, params=params, auth=HTTPDigestAuth(
             config['tvhUser'], config['tvhPassword']))
-        entries_full = r.json()['entries']
+        entries_full = r.json(strict=False)['entries']
         majorCategories = {}
         genres = {}
         for entry in entries:
@@ -182,7 +182,7 @@ def _get_xmltv():
         r = requests.get(url, params=params,  auth=HTTPDigestAuth(
             config['tvhUser'], config['tvhPassword']))
         logger.info('downloading epg grid from %s', r.url)
-        epg_events_grid = r.json()['entries']
+        epg_events_grid = r.json(strict=False)['entries']
         epg_events = {}
         event_keys = {}
         for epg_event in epg_events_grid:
@@ -303,7 +303,8 @@ def _get_xmltv():
         logger.info("returning epg")
         return ElementTree.tostring(root)
     except requests.exceptions.RequestException as e:  # This is the correct syntax
-        logger.error('An error occured: %s' + repr(e))
+        logger.error('An error occured: ' + repr(e))
+        raise e
 
 
 def _start_ssdp():


### PR DESCRIPTION
I had a problem with a JSONDecodeError, which I think was caused by unescaped characters in the EPG. The modification in this pull request uses non-strict JSON parsing option to handle this better.
There was also a minor formatting error in the exception handler which is fixed, and the exception is raised again by the function to prevent a flask error (the function _get_xmltv() cannot return None) which made it a bit harder to debug.
